### PR TITLE
fix: 경기 수기 등록 시 최신 시즌 정보가 포함되도록 수정

### DIFF
--- a/cogs/match.py
+++ b/cogs/match.py
@@ -77,6 +77,10 @@ class MatchConfirmView(discord.ui.View):
 
         try:
             async with AsyncSessionLocal() as session:
+                s_res = await session.execute(text("SELECT id FROM seasons ORDER BY start_date DESC NULLS LAST, id DESC LIMIT 1"))
+                season_row = s_res.fetchone()
+                season_id = season_row[0] if season_row else None
+
                 w_res = await session.execute(text("SELECT nickname, race FROM users WHERE nickname = :name"), {"name": self.winner_name})
                 winner_row = w_res.fetchone()
                 l_res = await session.execute(text("SELECT nickname, race FROM users WHERE nickname = :name"), {"name": self.loser_name})
@@ -98,7 +102,8 @@ class MatchConfirmView(discord.ui.View):
                         loser_race, 
                         winner_apm, 
                         loser_apm, 
-                        replay_file
+                        replay_file,
+                        season_id
                     ) VALUES (
                         :discord_id,
                         NOW(),
@@ -110,7 +115,8 @@ class MatchConfirmView(discord.ui.View):
                         :l_race,
                         0,
                         0,
-                        :replay_file
+                        :replay_file,
+                        :season_id
                     )
                 """
                 await session.execute(text(insert_q), {
@@ -120,7 +126,8 @@ class MatchConfirmView(discord.ui.View):
                     "w_race": winner_row.race,
                     "l_name": loser_row.nickname,
                     "l_race": loser_row.race,
-                    "replay_file": f"manual_entry_{uuid.uuid4().hex}"
+                    "replay_file": f"manual_entry_{uuid.uuid4().hex}",
+                    "season_id": season_id
                 })
                 await session.commit()
             
@@ -175,6 +182,10 @@ class MatchBatchModal(discord.ui.Modal, title='다중 경기 일괄 입력'):
         
         try:
             async with AsyncSessionLocal() as session:
+                s_res = await session.execute(text("SELECT id FROM seasons ORDER BY start_date DESC NULLS LAST, id DESC LIMIT 1"))
+                season_row = s_res.fetchone()
+                season_id = season_row[0] if season_row else None
+
                 res = await session.execute(text("SELECT nickname, race FROM users WHERE nickname IN (:my_n, :opp_n)"), 
                                             {"my_n": self.me_name, "opp_n": self.opponent_name})
                 users = {row.nickname: row for row in res.fetchall()}
@@ -276,11 +287,11 @@ class MatchBatchModal(discord.ui.Modal, title='다중 경기 일괄 입력'):
                         INSERT INTO games (
                             discord_id, played_at, map_name, game_duration_seconds, 
                             winner_name, winner_race, loser_name, loser_race, 
-                            winner_apm, loser_apm, replay_file
+                            winner_apm, loser_apm, replay_file, season_id
                         ) VALUES (
                             :u_id, NOW(), :map, 0,
                             :w_n, :w_r, :l_n, :l_r,
-                            0, 0, :replay_file
+                            0, 0, :replay_file, :season_id
                         )
                     """
                     await session.execute(text(insert_q), {
@@ -290,7 +301,8 @@ class MatchBatchModal(discord.ui.Modal, title='다중 경기 일괄 입력'):
                         "w_r": winner.race,
                         "l_n": loser.nickname,
                         "l_r": loser.race,
-                        "replay_file": f"manual_entry_{uuid.uuid4().hex}"
+                        "replay_file": f"manual_entry_{uuid.uuid4().hex}",
+                        "season_id": season_id
                     })
                     desc += f"- **{m['map']}**: {res_str}\n"
                     processed_count += 1


### PR DESCRIPTION
## PR 타입
<!-- 해당하는 항목에 x를 채워주세요 -->
- [ ] ✨ Feature — 새로운 기능
- [x] 🧹 Refactor — 코드 개선 / 구조 변경
- [ ] 🚨 Hotfix — 긴급 버그 수정

---

## 📌 작업 내용
<!-- 무엇을 했는지 간단히 설명해주세요 -->
- 경기등록시 시즌테이블 조회하여 최근 날짜 기준 시즌으로/날짜가 없다면 시즌id 가장 높은것으로 
- 게임테이블 시즌id에 등록

---

## 🔗 관련 이슈
Closes #36 

---

## 🧩 변경 사항
<!-- 주요 변경 내용을 적어주세요 -->
- 

---

## 🧪 테스트 방법
- [x] 기능 정상 동작 확인
- [ ] 예외 케이스 테스트

1. 
2. 
3. 

---

## 📸 스크린샷
<!-- UI 변경이 있다면 첨부해주세요 (선택사항) -->
<img width="388" height="269" alt="image" src="https://github.com/user-attachments/assets/7a2fd0dc-4e77-491d-9064-c9bb7122c99d" />

---

## 💬 리뷰 포인트
<!-- 집중적으로 봐줬으면 하는 부분을 알려주세요 -->
- 이런건가...? 하 맨날 메인에 올렸다가 지웠다가 함..
